### PR TITLE
Update peer.py

### DIFF
--- a/p2p/peer.py
+++ b/p2p/peer.py
@@ -146,7 +146,7 @@ class BasePeer(Service):
         # established from a dial-out or dial-in (True: dial-in, False:
         # dial-out)
         # TODO: rename to `dial_in` and have a computed property for `dial_out`
-        self.inbound = connection.is_dial_in
+        self.is_inbound = connection.is_dial_in
         self._subscribers: List[PeerSubscriber] = []
 
         # A counter of the number of messages this peer has received for each


### PR DESCRIPTION
Renamed 'Peer.inbound' to 'Peer.is_inbound'.

### What was wrong?
This property violates what I consider standard naming scheme for booleans. Should be one of
- is_inbound
- is_dial_in

### How was it fixed?
- Decide which is better and update the codebase to use this terminology consistently.
- Create a computed @property for the inverse (is_outbound or is_dial_out).

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [ ] Clean up commit history

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

[//]: # (See: https://trinity-client.readthedocs.io/en/latest/contributing.html#pull-requests)
- [ ] Add entry to the [release notes](https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](
![cuteanimal](https://user-images.githubusercontent.com/48244637/100354897-f2747980-3018-11eb-965a-9de30379c29c.jpeg)
)
